### PR TITLE
Add support for python 2.6

### DIFF
--- a/duel/__init__.py
+++ b/duel/__init__.py
@@ -41,7 +41,7 @@ class duel (gdb.Command):
                 gdb.write("Aliases table:\n")
                 for k in sorted(expr.aliases.keys()):
                     n,v=expr.aliases[k]
-                    gdb.write("{}: {} = {}\n".format(k, n, expr.val2str(v)))
+                    gdb.write("{0}: {1} = {2}\n".format(k, n, expr.val2str(v)))
             else:
                 gdb.write("Aliases table empty\n")
         elif arg == 'clear':

--- a/duel/expr.py
+++ b/duel/expr.py
@@ -69,11 +69,11 @@ class UnaryBase(Expr):
 class Unary(UnaryBase):
     def __init__(self, n, a, v):
         super (Unary, self).__init__ (a)
-        self.name_ = n if '{' in n else n + '{}'
+        self.name_ = n if '{' in n else n + '{0}'
         self.value = v
 
 class Curlies(UnaryBase):
-    name_ = "({})"
+    name_ = "({0})"
     def eval(self):
         for n,v in self.arg1_.eval():
             yield val2str(v), v
@@ -89,7 +89,7 @@ class BinaryBase(Expr):
 class Binary(BinaryBase):
     def __init__(self, a1, n, a2, v):
         super (Binary, self).__init__ (a1, a2)
-        self.name_ = n if '{' in n else '{} ' + n + ' {}'
+        self.name_ = n if '{' in n else '{0} ' + n + ' {1}'
         self.value = v
 
 class Filter(Binary):
@@ -114,15 +114,15 @@ class Struct(BinaryBase):
             underscores.pop()
 
 class StructWalk(BinaryBase):
-    name_ = '{}-->{}'
+    name_ = '{0}-->{1}'
     def path2str(self, path):
         if len(path) == 1: return path[0]
         s, prev, cnt = path[0], path[1], 1
         for m in path[2:] + [None]:
             if m == prev: cnt += 1
             else:
-                if cnt == 1: s += '->{}'.format(prev)
-                else: s += '-->{}[[{}]]'.format(prev, cnt)
+                if cnt == 1: s += '->{0}'.format(prev)
+                else: s += '-->{0}[[{1}]]'.format(prev, cnt)
                 prev, cnt = m, 1
         return s
     @scoped
@@ -142,7 +142,7 @@ class StructWalk(BinaryBase):
                 underscores.pop()
 
 class TakeNth(BinaryBase):
-    name_ = '{}[[{}]]'
+    name_ = '{0}[[{1}]]'
     def eval(self):
         for n2,v2 in self.arg2_.eval():
             val = self.arg1_.eval()
@@ -151,7 +151,7 @@ class TakeNth(BinaryBase):
             yield self.name_.format(self.arg1_.name(), n2), v1
 
 class Until(BinaryBase):
-    name_ = '{}@{}'
+    name_ = '{0}@{1}'
     @scoped
     def eval(self):
         if isinstance(self.arg2_, Literal): f = lambda x,y: x == y
@@ -180,7 +180,7 @@ class URange(UnaryBase):
                 yield val2str(v), v
 
 class BiRange(BinaryBase):
-    name_ = '{}..{}'
+    name_ = '{0}..{1}'
     def eval(self):
         for n1,v1 in self.arg1_.eval():
             for n2,v2 in self.arg2_.eval():
@@ -192,7 +192,7 @@ class BiRange(BinaryBase):
 class EagerGrouping(UnaryBase):
     def __init__(self, n, a, v):
         super (EagerGrouping, self).__init__ (a)
-        self.name_, self.add = n + '{}', v
+        self.name_, self.add = n + '{0}', v
     def eval(self):
         i = 0
         for n,v in self.arg1_.eval(): i =  self.add(i, v)
@@ -201,7 +201,7 @@ class EagerGrouping(UnaryBase):
 class LazyGrouping(UnaryBase):
     def __init__(self, n, a, v0, v):
         super (LazyGrouping, self).__init__ (a)
-        self.name_, self.init_val, self.add = n + '{}', v0, v
+        self.name_, self.init_val, self.add = n + '{0}', v0, v
     def eval(self):
         i = self.init_val
         for n,v in self.arg1_.eval():
@@ -225,7 +225,7 @@ class Ternary(Expr):
                     if v1: yield self.name_.format(n1, n2), v2
 
 class Alias(BinaryBase):
-    name_ = '{} := {}'
+    name_ = '{0} := {1}'
     def eval(self):
         for n2,v2 in self.arg2_.eval():
             try: v2 = v2.reference_value()
@@ -234,7 +234,7 @@ class Alias(BinaryBase):
             yield self.arg1_.name(), v2
 
 class Enumerate(BinaryBase):
-    name_ = '{}#{}'
+    name_ = '{0}#{1}'
     def eval(self):
         for i, nv1 in enumerate(self.arg1_.eval()):
             aliases[self.arg2_.name()] = (str(i), i)
@@ -258,7 +258,7 @@ class Statement(Expr):
             yield n2, v2
 
 class Foreach(BinaryBase):
-    name_ = '{} => {}'
+    name_ = '{0} => {1}'
     @underscored
     def eval(self):
         for n1,v1 in self.arg1_.eval():
@@ -268,7 +268,7 @@ class Foreach(BinaryBase):
             underscores.pop()
 
 class Call(BinaryBase):
-    name_ = '{}({})'
+    name_ = '{0}({1})'
     def eval(self):
         for n1,v1 in self.arg1_.eval():
             args = self.arg2_.args_

--- a/duel/parser.py
+++ b/duel/parser.py
@@ -41,7 +41,7 @@ def make_typespec_parser():
             return Terminal(self, c_pos, t)
         else:
             if parser.debug:
-                parser.dprint("-- NoMatch at {}".format(c_pos))
+                parser.dprint("-- NoMatch at {0}".format(c_pos))
             parser._nm_raise(self, c_pos, parser)
     self.to_match=self.rule_name
     self._parse = parse
@@ -147,7 +147,7 @@ class DuelVisitor(PTNodeVisitor):
         return expr.Call(ch[0], expr.List([ch[2]]))
     def visit_parens(self, node, ch):
         op, arg = ch[0], ch[1]
-        if op == '(': return expr.Unary('({})', arg, lambda x: x)
+        if op == '(': return expr.Unary('({0})', arg, lambda x: x)
         if op == '{': return expr.Curlies(arg)
     def visit_term19a(self, node, ch):
         if len(ch) == 1: return ch[0]
@@ -156,9 +156,9 @@ class DuelVisitor(PTNodeVisitor):
         l = ch.pop(0)
         while len(ch):
             op, r = ch.pop(0), ch.pop(0)
-            if   op == '[':   l, _ = expr.Binary(l, '{}[{}]', r, lambda x,y: x[int(y)]), ch.pop(0)
-            elif op == '.':   l    = expr.Struct(l, '{}.{}', r)
-            elif op == '->':  l    = expr.Struct(l, '{}->{}', r)
+            if   op == '[':   l, _ = expr.Binary(l, '{0}[{1}]', r, lambda x,y: x[int(y)]), ch.pop(0)
+            elif op == '.':   l    = expr.Struct(l, '{0}.{1}', r)
+            elif op == '->':  l    = expr.Struct(l, '{0}->{1}', r)
             elif op == '-->': l    = expr.StructWalk(l, r)
             elif op == '[[':  l, _ = expr.TakeNth(l, r), ch.pop(0)
             elif op == '@':   l    = expr.Until(l, r)
@@ -205,8 +205,8 @@ class DuelVisitor(PTNodeVisitor):
     def visit_term14(self, node, ch):
         if len(ch) == 1: return ch[0]
         if len(ch) == 3: return expr.BiRange(ch[0], ch[2])
-        if ch[0] == '..': return expr.URange('..{}', ch[1], True)
-        return expr.URange('{}..', ch[0], False)
+        if ch[0] == '..': return expr.URange('..{0}', ch[1], True)
+        return expr.URange('{0}..', ch[0], False)
     def visit_term13(self, node, ch):
         l = ch.pop(0)
         while len(ch):
@@ -261,7 +261,7 @@ class DuelVisitor(PTNodeVisitor):
         return l
     def visit_term6(self, node, ch):
         if len(ch) == 1: return ch[0]
-        return expr.Ternary('{} ? {} : {}', ch[0], ch[2], ch[4])
+        return expr.Ternary('{0} ? {1} : {2}', ch[0], ch[2], ch[4])
     def visit_term5(self, node, ch):
         l = ch.pop(0)
         while len(ch):
@@ -286,8 +286,8 @@ class DuelVisitor(PTNodeVisitor):
         return l
     def visit_ifterm(self, node, ch):
         if len(ch) == 1: return ch[0]
-        if len(ch) == 5: return expr.Ternary('if({}) {}', ch[2], ch[4], None)
-        return expr.Ternary('if({}) {} else {}', ch[2], ch[4], ch[6])
+        if len(ch) == 5: return expr.Ternary('if({0}) {1}', ch[2], ch[4], None)
+        return expr.Ternary('if({0}) {1} else {2}', ch[2], ch[4], ch[6])
     def visit_whileterm(self, node, ch):
         if len(ch) == 1: return ch[0]
         not_implemented()
@@ -313,4 +313,4 @@ def eval(arg):
     assert len(expr.underscores) == 0
 
     for name, val in expr_tree.eval():
-        gdb.write('{} = {}\n'.format(name, expr.val2str(val)))
+        gdb.write('{0} = {1}\n'.format(name, expr.val2str(val)))

--- a/pretty_printer/__init__.py
+++ b/pretty_printer/__init__.py
@@ -52,7 +52,7 @@ def PrettyPrinter(arg):
             def __call__(self, val):
                 prefix = ''
                 if val.type.code == gdb.TYPE_CODE_PTR:
-                    prefix = '({}) {:#08x} '.format(str(val.type), long(val))
+                    prefix = '({0}) {1:#08x} '.format(str(val.type), long(val))
                     try: val = val.dereference()
                     except: return None
                 valtype=val.type.unqualified()


### PR DESCRIPTION
I've got the following error using duel with python version 2.6.6:
```gdb
(gdb) dl 1..2
DUEL.py 0.9.3, high level data exploration language. "dl" for help
zero length field name in format
```

Replacing `{} ... {}` with `{0} ... {n}` fixes this issue.